### PR TITLE
Add support for UTF8 entry names

### DIFF
--- a/winzipaes/src/de/idyl/winzipaes/AesZipFileEncrypter.java
+++ b/winzipaes/src/de/idyl/winzipaes/AesZipFileEncrypter.java
@@ -45,6 +45,10 @@ public class AesZipFileEncrypter {
 	// --------------------------------------------------------------------------
 
 	protected ExtZipOutputStream zipOS;
+	
+	// --------------------------------------------------------------------------
+	
+	protected boolean enableUTF8;
 
 	/**
 	 * 
@@ -54,6 +58,7 @@ public class AesZipFileEncrypter {
 	public AesZipFileEncrypter(String pathName, AESEncrypter encrypter) throws IOException {
 		zipOS = new ExtZipOutputStream(new File(pathName));
 		this.encrypter = encrypter;
+		this.enableUTF8 = false;
 	}
 
 	/**
@@ -64,11 +69,13 @@ public class AesZipFileEncrypter {
 	public AesZipFileEncrypter(File outFile, AESEncrypter encrypter) throws IOException {
 		zipOS = new ExtZipOutputStream(outFile);
 		this.encrypter = encrypter;
+		this.enableUTF8 = false;
 	}
 
 	public AesZipFileEncrypter(OutputStream outFile, AESEncrypter encrypter) throws IOException {
 		zipOS = new ExtZipOutputStream(outFile);
 		this.encrypter = encrypter;
+		this.enableUTF8 = false;
 	}
 
 	// --------------------------------------------------------------------------
@@ -110,7 +117,7 @@ public class AesZipFileEncrypter {
 		entry.setSize(zipEntry.getSize());
 		entry.setCompressedSize(zipEntry.getCompressedSize() + 28);
 		entry.setTime(zipEntry.getTime());
-		entry.initEncryptedEntry();
+		entry.initEncryptedEntry(enableUTF8);
 
 		zipOS.putNextEntry(entry);
 		// ZIP-file data contains: 1. salt 2. pwVerification 3. encryptedContent 4. authenticationCode
@@ -195,7 +202,7 @@ public class AesZipFileEncrypter {
 		entry.setSize(inputLen);
 		entry.setCompressedSize(data.length + 28);
 		entry.setTime((new java.util.Date()).getTime());
-		entry.initEncryptedEntry();
+		entry.initEncryptedEntry(enableUTF8);
 
 		zipOS.putNextEntry(entry);
 		// ZIP-file data contains: 1. salt 2. pwVerification 3. encryptedContent 4. authenticationCode
@@ -306,5 +313,10 @@ public class AesZipFileEncrypter {
 			enc.close();
 		}
 	}
-
+	
+	public void enableUTF8()
+	{
+		enableUTF8 = true;
+		zipOS.enableUTF8();
+	}
 }

--- a/winzipaes/src/de/idyl/winzipaes/impl/ExtZipEntry.java
+++ b/winzipaes/src/de/idyl/winzipaes/impl/ExtZipEntry.java
@@ -35,10 +35,16 @@ public class ExtZipEntry extends ZipEntry {
 	}
 	
 	public void initEncryptedEntry() {
+		initEncryptedEntry(false);
+	}
+	
+	public void initEncryptedEntry(boolean enableUTF8) {
 		setCrc(0); // CRC-32 / for encrypted files it's 0 as AES/MAC checks integritiy
 
 		this.flag |= 1; // bit0 - encrypted
 		// flag |= 8; // bit3 - use data descriptor
+		if(enableUTF8)
+			this.flag |= 1 << 11;
 
 		this.primaryCompressionMethod = 0x63;
 

--- a/winzipaes/src/de/idyl/winzipaes/impl/ExtZipOutputStream.java
+++ b/winzipaes/src/de/idyl/winzipaes/impl/ExtZipOutputStream.java
@@ -18,10 +18,12 @@ public class ExtZipOutputStream implements ZipConstants {
 
 	public ExtZipOutputStream(File file) throws IOException {
 		out = new FileOutputStream(file);
+		encoding = "iso-8859-1";
 	}
 
 	public ExtZipOutputStream(OutputStream out) {
 		this.out = out;
+		encoding = "iso-8859-1";
 	}
 
 	protected String comment;
@@ -30,6 +32,8 @@ public class ExtZipOutputStream implements ZipConstants {
 
 	/** number of bytes written to out */
 	protected int written;
+	
+	protected String encoding;
 
 	public int getWritten() {
 		return this.written;
@@ -85,7 +89,7 @@ public class ExtZipOutputStream implements ZipConstants {
 		writeInt((int) entry.getCompressedSize()); // compressed size
 		writeInt((int) entry.getSize()); // uncompressed size
 
-		writeShort(entry.getName().length()); // file name length
+		writeShort(entry.getName().getBytes(encoding).length); // file name length
 		if (entry.getExtra() != null) {
 			writeShort(entry.getExtra().length); // extra field length
 		} else {
@@ -108,7 +112,7 @@ public class ExtZipOutputStream implements ZipConstants {
 
 		writeInt(entry.getOffset()); // relative offset of local header 4 bytes
 
-		writeBytes(entry.getName().getBytes("iso-8859-1"));
+		writeBytes(entry.getName().getBytes(encoding));
 
 		writeExtraBytes(entry);
 	}
@@ -131,7 +135,7 @@ public class ExtZipOutputStream implements ZipConstants {
 		writeInt(LOCSIG);
 
 		writeFileInfo(entry);
-		writeBytes(entry.getName().getBytes("iso-8859-1"));
+		writeBytes(entry.getName().getBytes(encoding));
 		writeExtraBytes(entry);
 	}
 
@@ -182,6 +186,11 @@ public class ExtZipOutputStream implements ZipConstants {
 
 	public void setComment(String comment) {
 		this.comment = comment;
+	}
+	
+	public void enableUTF8()
+	{
+		this.encoding = "UTF8";
 	}
 
 }


### PR DESCRIPTION
Add an option to support UTF-8 encoded entry names. This enables to support entries with accents in their names.